### PR TITLE
Singularize model name

### DIFF
--- a/draft_generators.gemspec
+++ b/draft_generators.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.require_paths = ["lib"]
   s.authors = ["Raghu Betina"]
-  s.date = "2018-01-31"
+  s.date = "2018-02-06"
   s.description = "This is a set of generators that help beginners learn to program. Primarily, they generate code that is more explicit and verbose and less idiomatic and \u{201c}magical\u{201d} than the built-in scaffold generator, which is helpful for beginners while they are learning how exactly things are wired together."
   s.email = "raghu@firstdraft.com"
   s.extra_rdoc_files = [

--- a/lib/draft_generators.rb
+++ b/lib/draft_generators.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'devise'
+require "devise"
 
 module DraftGenerators
 end

--- a/lib/generators/draft/devise/devise_generator.rb
+++ b/lib/generators/draft/devise/devise_generator.rb
@@ -24,7 +24,7 @@ module Draft
       unless model_exists?
         uncomment_lines("config/initializers/devise.rb",
           /.*config.scoped_views = false/)
-        end
+      end
     end
 
     def orm

--- a/lib/generators/draft/model/model_generator.rb
+++ b/lib/generators/draft/model/model_generator.rb
@@ -6,7 +6,7 @@ module Draft
     argument :attributes, type: :array, default: [], banner: "field[:type][:index] field[:type][:index]"
     
     def generate_model
-      invoke 'model'
+      invoke "model"
     end
 
     def generate_active_admin

--- a/lib/generators/draft/model/model_generator.rb
+++ b/lib/generators/draft/model/model_generator.rb
@@ -4,7 +4,7 @@ require "rails/generators/named_base"
 module Draft
   class ModelGenerator < Rails::Generators::NamedBase
     argument :attributes, type: :array, default: [],
-              banner: "field[:type][:index] field[:type][:index]"
+                          banner: "field[:type][:index] field[:type][:index]"
     def generate_model
       invoke "model"
     end
@@ -32,7 +32,7 @@ module Draft
       inside "app" do
         inside "admin" do
           insert_into_file "#{file_name}.rb", after: sentinel do
-            "\n  permit_params #{attributes_names.map { |name| ":#{name}" }.join(", ")}\n"
+            "\n  permit_params #{attributes_names.map { |name| ":#{name}" }.join(', ')}\n"
           end
         end
       end

--- a/lib/generators/draft/model/model_generator.rb
+++ b/lib/generators/draft/model/model_generator.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "rails/generators/named_base"
-
 module Draft
   class ModelGenerator < Rails::Generators::NamedBase
     argument :attributes, type: :array, default: [],

--- a/lib/generators/draft/model/model_generator.rb
+++ b/lib/generators/draft/model/model_generator.rb
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
-require 'rails/generators/named_base'
+
+require "rails/generators/named_base"
 
 module Draft
   class ModelGenerator < Rails::Generators::NamedBase
-    argument :attributes, type: :array, default: [], banner: "field[:type][:index] field[:type][:index]"
-    
+    argument :attributes, type: :array, default: [],
+              banner: "field[:type][:index] field[:type][:index]"
     def generate_model
       invoke "model"
     end
@@ -17,7 +18,7 @@ module Draft
       end
     end
 
-  private
+    private
 
     def permit_active_admin_params
       if File.exist?("app/admin/#{singular_table_name}.rb")

--- a/lib/generators/draft/model/model_generator.rb
+++ b/lib/generators/draft/model/model_generator.rb
@@ -1,10 +1,13 @@
 # frozen_string_literal: true
-
-require "rails/generators/active_record/model/model_generator"
+require 'rails/generators/named_base'
 
 module Draft
-  class ModelGenerator < ActiveRecord::Generators::ModelGenerator
-    source_root ActiveRecord::Generators::ModelGenerator.source_root
+  class ModelGenerator < Rails::Generators::NamedBase
+    argument :attributes, type: :array, default: [], banner: "field[:type][:index] field[:type][:index]"
+    
+    def generate_model
+      invoke 'model'
+    end
 
     def generate_active_admin
       if Gem.loaded_specs.has_key? "activeadmin"

--- a/lib/generators/draft/model/model_generator.rb
+++ b/lib/generators/draft/model/model_generator.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "rails/generators/named_base"
+
 module Draft
   class ModelGenerator < Rails::Generators::NamedBase
     argument :attributes, type: :array, default: [],


### PR DESCRIPTION
- Invoke model generator directly instead of inheriting activerecord model generator so that it checks for plural name 
- Fixes #28 .