### PR TITLE
Disambiguating by breaking more conventions

### DIFF
--- a/lib/generators/draft/layout/templates/_flashes.html.erb
+++ b/lib/generators/draft/layout/templates/_flashes.html.erb
@@ -1,23 +1,27 @@
-<div class="row">
-  <div class="col-md-12">
-    <%% if notice.present? %>
-      <div class="alert alert-success alert-dismissable" role="alert">
-        <%%= notice %>
+<%% if notice.present? %>
+  <div class="alert alert-dismissable alert-success">
+    <div class="container">
+      <div class="row">
+        <div class="col-lg-12">
+          <button class="close" data-dismiss="alert">&times;</button>
 
-        <button type="button" class="close" data-dismiss="alert" aria-label="Close">
-          <span aria-hidden="true">&times;</span>
-        </button>
+          <%%= notice %>
+        </div>
       </div>
-    <%% end %>
-
-    <%% if alert.present? %>
-      <div class="alert alert-warning alert-dismissable" role="alert">
-        <%%= alert %>
-
-        <button type="button" class="close" data-dismiss="alert" aria-label="Close">
-          <span aria-hidden="true">&times;</span>
-        </button>
-      </div>
-    <%% end %>
+    </div>
   </div>
-</div>
+<%% end %>
+
+<%% if alert.present? %>
+  <div class="alert alert-dismissable alert-success">
+    <div class="container">
+      <div class="row">
+        <div class="alert alert-dismissable alert-warning">
+          <button class="close" data-dismiss="alert">&times;</button>
+
+          <%%= alert %>
+        </div>
+      </div>
+    </div>
+  </div>
+<%% end %>

--- a/lib/generators/draft/layout/templates/_navbar.html.erb
+++ b/lib/generators/draft/layout/templates/_navbar.html.erb
@@ -50,5 +50,5 @@
 <% end -%>
 <% end -%>
     </div> <!-- .navbar-collapse -->
-  </div> <!-- .container -->
+  </div> <!-- .container -->>
 </nav>

--- a/lib/generators/draft/layout/templates/layout.html.erb
+++ b/lib/generators/draft/layout/templates/layout.html.erb
@@ -22,9 +22,9 @@
 <body>
   <%%= render "shared/navbar" %>
 
-  <div class="container">
-    <%%= render "shared/flashes" %>
+  <%%= render "shared/flashes" %>
 
+  <div class="container">
     <%%= yield %>
   </div>
 

--- a/lib/generators/draft/resource/resource_generator.rb
+++ b/lib/generators/draft/resource/resource_generator.rb
@@ -14,9 +14,9 @@ module Draft
       return if skip_controller?
 
       if read_only?
-        template "controllers/read_only_controller.rb", "app/controllers/#{plural_table_name.underscore}_controller.rb"
+        template "controllers/read_only_controller.rb", "app/controllers/#{plural_table_name}_controller.rb"
       else
-        template "controllers/controller.rb", "app/controllers/#{plural_table_name.underscore}_controller.rb"
+        template "controllers/controller.rb", "app/controllers/#{plural_table_name}_controller.rb"
       end
     end
 
@@ -48,8 +48,8 @@ module Draft
       return
       # return if read_only? || skip_controller? || skip_model?
 
-      template "specs/crud_spec.rb", "spec/features/crud_#{plural_table_name.underscore}_spec.rb"
-      template "specs/factories.rb", "spec/factories/#{plural_table_name.underscore}.rb"
+      template "specs/crud_spec.rb", "spec/features/crud_#{plural_table_name}_spec.rb"
+      template "specs/factories.rb", "spec/factories/#{plural_table_name}.rb"
     end
 
   private
@@ -70,7 +70,7 @@ module Draft
         get("/#{plural_table_name}/:id_to_display", { :controller => "#{plural_table_name}", :action => "show" })
 
         # UPDATE
-        get("/#{plural_table_name}/:prefill_with_id/edit", { :controller => "#{plural_table_name}", :action => "edit_form" })
+        get("/#{plural_table_name}/:id_to_edit/edit", { :controller => "#{plural_table_name}", :action => "edit_form" })
         #{skip_post? ? "get" : "post"}("/update_#{singular_table_name}/:id_to_modify", { :controller => "#{plural_table_name}", :action => "update_row" })
 
         # DELETE
@@ -132,7 +132,7 @@ module Draft
       elsif skip_redirect?
         %w(index show new_form create_row edit_form update_row destroy_row)
       else
-        %w(index new_form edit_form show)
+        %w(index show new_form new_form_with_errors edit_form edit_form_with_errors)
       end
     end
 

--- a/lib/generators/draft/resource/templates/controllers/controller.rb
+++ b/lib/generators/draft/resource/templates/controllers/controller.rb
@@ -1,97 +1,102 @@
 class <%= plural_table_name.camelize %>Controller < ApplicationController
   def index
-    @<%= plural_table_name.underscore %> = <%= class_name.singularize %>.all
+    @list_of_<%= plural_table_name %> = <%= class_name.singularize %>.all.order({ :created_at => :desc })
 
-    render("<%= singular_table_name.underscore %>_templates/index.html.erb")
+    render("<%= singular_table_name %>_templates/index.html.erb")
   end
 
   def show
-    @<%= singular_table_name.underscore %> = <%= class_name.singularize %>.find(params[:id_to_display])
+    id_of_<%= singular_table_name %>_to_show = params.fetch("id_to_display")
 
-    render("<%= singular_table_name.underscore %>_templates/show.html.erb")
+    @<%= singular_table_name %>_to_show = <%= class_name.singularize %>.find(id_of_<%= singular_table_name %>_to_show)
+
+    render("<%= singular_table_name %>_templates/show.html.erb")
   end
 
   def new_form
-<% unless skip_validation_alerts? -%>
-    @<%= singular_table_name.underscore %> = <%= class_name.singularize %>.new
-<% end -%>
-    render("<%= singular_table_name.underscore %>_templates/new_form.html.erb")
+    render("<%= singular_table_name %>_templates/new_form.html.erb")
   end
 
   def create_row
-    @<%= singular_table_name.underscore %> = <%= class_name.singularize %>.new
+    @<%= singular_table_name %> = <%= class_name.singularize %>.new
 
 <% attributes.each do |attribute| -%>
-    @<%= singular_table_name.underscore %>.<%= attribute.column_name %> = params[:<%= attribute.column_name %>]
+    @<%= singular_table_name %>.<%= attribute.column_name %> = params.fetch("<%= attribute.column_name %>_from_form")
 <% end -%>
 
 <% unless skip_validation_alerts? -%>
-    save_status = @<%= singular_table_name.underscore %>.save
+    save_status = @<%= singular_table_name %>.save
 
     if save_status == true
-      redirect_to("/<%= @plural_table_name.underscore %>", :notice => "<%= singular_table_name.humanize %> created successfully.")
+      redirect_to("/<%= plural_table_name %>", :notice => "<%= singular_table_name.humanize %> created successfully.")
     else
-      render("<%= singular_table_name.underscore %>_templates/new_form.html.erb")
+      render("<%= singular_table_name %>_templates/new_form_with_errors.html.erb")
     end
 <% else -%>
-    @<%= singular_table_name.underscore %>.save
+    @<%= singular_table_name %>.save
 
 <% unless skip_redirect? -%>
-    redirect_to("/<%= @plural_table_name.underscore %>")
+    redirect_to("/<%= plural_table_name %>")
 <% else -%>
-    @current_count = <%= class_name.singularize %>.count
+    @current_<%= singular_table_name %>_count = <%= class_name.singularize %>.count
 
-    render("<%= singular_table_name.underscore %>_templates/create_row.html.erb")
+    render("<%= singular_table_name %>_templates/create_row.html.erb")
 <% end -%>
 <% end -%>
   end
 
   def edit_form
-    @<%= singular_table_name.underscore %> = <%= class_name.singularize %>.find(params[:prefill_with_id])
+    id_of_<%= singular_table_name %>_to_prefill = params.fetch("id_to_edit")
 
-    render("<%= singular_table_name.underscore %>_templates/edit_form.html.erb")
+    @<%= singular_table_name %> = <%= class_name.singularize %>.find(id_of_<%= singular_table_name %>_to_prefill)
+
+    render("<%= singular_table_name %>_templates/edit_form.html.erb")
   end
 
   def update_row
-    @<%= singular_table_name.underscore %> = <%= class_name.singularize %>.find(params[:id_to_modify])
+    id_of_<%= singular_table_name %>_to_change = params.fetch("id_to_modify")
+
+    @<%= singular_table_name %>_to_change = <%= class_name.singularize %>.find(id_of_<%= singular_table_name %>_to_change)
 
 <% attributes.each do |attribute| -%>
-    @<%= singular_table_name.underscore %>.<%= attribute.column_name %> = params[:<%= attribute.column_name %>]
+    @<%= singular_table_name %>_to_change.<%= attribute.column_name %> = params.fetch("<%= attribute.column_name %>_from_form")
 <% end -%>
 
 <% unless skip_validation_alerts? -%>
-    save_status = @<%= singular_table_name.underscore %>.save
+    save_status = @<%= singular_table_name %>_to_change.save
 
     if save_status == true
-      redirect_to("/<%= @plural_table_name.underscore %>/#{@<%= singular_table_name.underscore %>.id}", :notice => "<%= singular_table_name.humanize %> updated successfully.")
+      redirect_to("/<%= plural_table_name %>/#{@<%= singular_table_name %>_to_change.id}", :notice => "<%= singular_table_name.humanize %> updated successfully.")
     else
-      render("<%= singular_table_name.underscore %>_templates/edit_form.html.erb")
+      render("<%= singular_table_name %>_templates/edit_form_with_errors.html.erb")
     end
 <% else -%>
-    @<%= singular_table_name.underscore %>.save
+    @<%= singular_table_name %>_to_change.save
 
 <% unless skip_redirect? -%>
-    redirect_to("/<%= @plural_table_name.underscore %>/#{@<%= singular_table_name.underscore %>.id}")
+    redirect_to("/<%= plural_table_name %>/#{@<%= singular_table_name %>_to_change.id}")
 <% else -%>
-    render("<%= singular_table_name.underscore %>_templates/update_row.html.erb")
+    render("<%= singular_table_name %>_templates/update_row.html.erb")
 <% end -%>
 <% end -%>
   end
 
   def destroy_row
-    @<%= singular_table_name.underscore %> = <%= class_name.singularize %>.find(params[:id_to_remove])
+    id_of_<%= singular_table_name %>_to_delete = params.fetch("id_to_remove")
 
-    @<%= singular_table_name.underscore %>.destroy
+    @<%= singular_table_name %>_to_toast = <%= class_name.singularize %>.find(id_of_<%= singular_table_name %>_to_delete)
+
+    @<%= singular_table_name %>_to_toast.destroy
 
 <% unless skip_validation_alerts? -%>
-    redirect_to("/<%= @plural_table_name.underscore %>", :notice => "<%= singular_table_name.humanize %> deleted successfully.")
+    redirect_to("/<%= plural_table_name %>", :notice => "<%= singular_table_name.humanize %> deleted successfully.")
 <% else -%>
 <% unless skip_redirect? -%>
-    redirect_to("/<%= @plural_table_name.underscore %>")
+    redirect_to("/<%= plural_table_name %>")
 <% else -%>
-    @remaining_count = <%= class_name.singularize %>.count
+    @remaining_<%= singular_table_name %>_count = <%= class_name.singularize %>.count
 
-    render("<%= singular_table_name.underscore %>_templates/destroy_row.html.erb")
+    render("<%= singular_table_name %>_templates/destroy_row.html.erb")
 <% end -%>
 <% end -%>
   end

--- a/lib/generators/draft/resource/templates/controllers/read_only_controller.rb
+++ b/lib/generators/draft/resource/templates/controllers/read_only_controller.rb
@@ -1,13 +1,15 @@
 class <%= plural_table_name.camelize %>Controller < ApplicationController
   def index
-    @<%= plural_table_name.underscore %> = <%= class_name.singularize %>.all
+    @list_of_<%= plural_table_name %> = <%= class_name.singularize %>.all.order({ :created_at => :desc })
 
-    render("<%= singular_table_name.underscore %>_templates/index.html.erb")
+    render("<%= singular_table_name %>_templates/index.html.erb")
   end
 
   def show
-    @<%= singular_table_name.underscore %> = <%= class_name.singularize %>.find(params[:id])
+    id_of_<%= singular_table_name %>_to_show = params.fetch("id_to_display")
 
-    render("<%= singular_table_name.underscore %>_templates/index.html.erb")
+    @<%= singular_table_name %>_to_show = <%= class_name.singularize %>.find(id_of_<%= singular_table_name %>_to_show)
+
+    render("<%= singular_table_name %>_templates/show.html.erb")
   end
 end

--- a/lib/generators/draft/resource/templates/views/create_row.html.erb
+++ b/lib/generators/draft/resource/templates/views/create_row.html.erb
@@ -1,11 +1,11 @@
-<h1>You created <%= singular_table_name.humanize.downcase %> #<%%= @<%= singular_table_name %>.id %>!</h1>
+<h1>You created a <%= singular_table_name.humanize.downcase %>!</h1>
 
 <p>
-  There are now <%%= @current_count %> <%= plural_table_name.humanize.downcase %>.
+  There are now <%%= @current_<%= singular_table_name %>_count %> <%= plural_table_name.humanize.downcase %>.
 </p>
 
 <p>
-  <a href="/<%= @plural_table_name.underscore %>">
+  <a href="/<%= plural_table_name %>">
     Click here
   </a>
 

--- a/lib/generators/draft/resource/templates/views/destroy_row.html.erb
+++ b/lib/generators/draft/resource/templates/views/destroy_row.html.erb
@@ -1,11 +1,11 @@
-<h1>You deleted <%= singular_table_name.humanize.downcase %> #<%%= @<%= singular_table_name %>.id %>!</h1>
+<h1>You deleted a <%= singular_table_name.humanize.downcase %>!</h1>
 
 <p>
-  There are now <%%= @remaining_count %> <%= plural_table_name.humanize.downcase %>.
+  There are now <%%= @remaining_<%= singular_table_name %>_count %> <%= plural_table_name.humanize.downcase %>.
 </p>
 
 <p>
-  <a href="/<%= @plural_table_name.underscore %>">
+  <a href="/<%= plural_table_name %>">
     Click here
   </a>
 

--- a/lib/generators/draft/resource/templates/views/edit_form_with_errors.html.erb
+++ b/lib/generators/draft/resource/templates/views/edit_form_with_errors.html.erb
@@ -1,3 +1,16 @@
+<% unless skip_validation_alerts? -%>
+<!-- Validation failure messages -->
+<%% if @<%= singular_table_name %>.errors.any? %>
+  <%% @<%= singular_table_name %>.errors.full_messages.each do |message| %>
+    <div class="alert alert-dismissable alert-danger">
+      <button class="close" data-dismiss="alert">&times;</button>
+
+      <%%= message %>
+    </div>
+  <%% end %>
+<%% end %>
+
+<% end -%>
 <h1>
   Edit <%= singular_table_name.humanize.downcase %> #<%%= @<%= singular_table_name %>.id %>
 </h1>
@@ -8,16 +21,15 @@
 <% attributes.each do |attribute| -%>
   <!-- Label and input for <%= attribute.column_name %> -->
 <% if attribute.field_type == :check_box -%>
-  <div class="form-check">
-    <input id="<%= attribute.column_name %>" class="form-check-input" name="<%= attribute.column_name %>" type="checkbox" value="1" <%%= "checked" if @<%= singular_table_name %>.<%= attribute.column_name %> %>>
-
-    <label for="<%= attribute.column_name %>" class="form-check-label">
+  <div class="checkbox">
+    <label for="<%= attribute.column_name %>">
+      <input type="checkbox" id="<%= attribute.column_name %>" name="<%= attribute.column_name %>_from_form" value="1" <%%= "checked" if @<%= singular_table_name %>.<%= attribute.column_name %> %>>
       <%= attribute.column_name.humanize %>
     </label>
   </div>
 <% else -%>
   <div class="form-group">
-    <label for="<%= attribute.column_name %>">
+    <label for="<%= attribute.column_name %>" class="control-label">
       <%= attribute.column_name.humanize %>
     </label>
 
@@ -30,7 +42,7 @@
 <% end -%>
 
 <% end -%>
-  <button class="btn btn-block btn-outline-secondary">
+  <button class="btn btn-default">
     Update <%= singular_table_name.humanize.downcase %>
   </button>
 </form>

--- a/lib/generators/draft/resource/templates/views/index.html.erb
+++ b/lib/generators/draft/resource/templates/views/index.html.erb
@@ -21,39 +21,23 @@
 
 <% end -%>
     <th>
-      Created at
-    </th>
-
-    <th>
-      Updated at
-    </th>
-
-    <th>
     </th>
   </tr>
 
-  <%% @<%= plural_table_name %>.each do |<%= singular_table_name %>| %>
+  <%% @list_of_<%= plural_table_name %>.each do |the_current_<%= singular_table_name %>| %>
   <tr>
     <td>
-      <%%= <%= singular_table_name %>.id %>
+      <%%= the_current_<%= singular_table_name %>.id %>
     </td>
 
 <% attributes.each do |attribute| -%>
     <td>
-      <%%= <%= singular_table_name %>.<%= attribute.column_name %> %>
+      <%%= the_current_<%= singular_table_name %>.<%= attribute.column_name %> %>
     </td>
 
 <% end -%>
     <td>
-      <%%= time_ago_in_words(<%= singular_table_name %>.created_at) %> ago
-    </td>
-
-    <td>
-      <%%= time_ago_in_words(<%= singular_table_name %>.updated_at) %> ago
-    </td>
-
-    <td>
-      <a href="/<%= plural_table_name %>/<%%= <%= singular_table_name %>.id %>">
+      <a href="/<%= plural_table_name %>/<%%= the_current_<%= singular_table_name %>.id %>">
         Show details
       </a>
     </td>

--- a/lib/generators/draft/resource/templates/views/new_form.html.erb
+++ b/lib/generators/draft/resource/templates/views/new_form.html.erb
@@ -1,18 +1,3 @@
-<% unless skip_validation_alerts? -%>
-<!-- Validation failure messages -->
-<%% if @<%= singular_table_name %>.errors.any? %>
-  <%% @<%= singular_table_name %>.errors.full_messages.each do |message| %>
-    <div class="alert alert-danger alert-dismissable" role="alert">
-      <%%= message %>
-
-      <button type="button" class="close" data-dismiss="alert" aria-label="Close">
-        <span aria-hidden="true">&times;</span>
-      </button>
-    </div>
-  <%% end %>
-<%% end %>
-
-<% end -%>
 <h1>
   Add a new <%= singular_table_name.humanize.downcase %>
 </h1>
@@ -37,9 +22,9 @@
     </label>
 
 <% if attribute.field_type == :text_area -%>
-    <textarea id="<%= attribute.column_name %>" name="<%= attribute.column_name %>" class="form-control" rows="3"><% unless skip_validation_alerts? -%><%%= @<%= singular_table_name %>.<%= attribute.column_name %> %><% end -%></textarea>
+    <textarea id="<%= attribute.column_name %>" name="<%= attribute.column_name %>_from_form" class="form-control" rows="3"></textarea>
 <% else -%>
-    <input type="text" id="<%= attribute.column_name %>" name="<%= attribute.column_name %>" class="form-control"<% unless skip_validation_alerts? -%> value="<%%= @<%= singular_table_name %>.<%= attribute.column_name %> %>"<% end -%>>
+    <input type="text" id="<%= attribute.column_name %>" name="<%= attribute.column_name %>_from_form" class="form-control">
 <% end -%>
   </div>
 <% end -%>

--- a/lib/generators/draft/resource/templates/views/new_form_with_errors.html.erb
+++ b/lib/generators/draft/resource/templates/views/new_form_with_errors.html.erb
@@ -1,0 +1,54 @@
+<% unless skip_validation_alerts? -%>
+<!-- Validation failure messages -->
+<%% if @<%= singular_table_name %>.errors.any? %>
+  <%% @<%= singular_table_name %>.errors.full_messages.each do |message| %>
+    <div class="alert alert-dismissable alert-danger">
+      <button class="close" data-dismiss="alert">&times;</button>
+
+      <%%= message %>
+    </div>
+  <%% end %>
+<%% end %>
+
+<% end -%>
+<h1>
+  Add a new <%= singular_table_name.humanize.downcase %>
+</h1>
+
+<hr>
+
+<form action="/create_<%= singular_table_name %>"<% unless skip_post? -%> method="post"<% end -%>>
+<% attributes.each do |attribute| -%>
+  <!-- Label and input for <%= attribute.column_name %> -->
+<% if attribute.field_type == :check_box -%>
+  <div class="checkbox">
+    <label for="<%= attribute.column_name %>">
+      <input type="checkbox" id="<%= attribute.column_name %>" name="<%= attribute.column_name %>_from_form" <% unless skip_validation_alerts? -%><%%= "checked" if @<%= singular_table_name %>.<%= attribute.column_name %> %><% end -%>>
+      <%= attribute.column_name.humanize %>
+    </label>
+  </div>
+<% else -%>
+  <div class="form-group">
+    <label for="<%= attribute.column_name %>" class="control-label">
+      <%= attribute.column_name.humanize %>
+    </label>
+
+<% if attribute.field_type == :text_area -%>
+    <textarea id="<%= attribute.column_name %>" name="<%= attribute.column_name %>_from_form" class="form-control" rows="3"><% unless skip_validation_alerts? -%><%%= @<%= singular_table_name %>.<%= attribute.column_name %> %><% end -%></textarea>
+<% else -%>
+    <input type="text" id="<%= attribute.column_name %>" name="<%= attribute.column_name %>_from_form" class="form-control"<% unless skip_validation_alerts? -%> value="<%%= @<%= singular_table_name %>.<%= attribute.column_name %> %>"<% end -%>>
+<% end -%>
+  </div>
+<% end -%>
+
+<% end -%>
+  <button class="btn btn-default">
+    Create <%= singular_table_name.humanize.downcase %>
+  </button>
+</form>
+
+<hr>
+
+<a href="/<%= plural_table_name %>">
+  Go back
+</a>

--- a/lib/generators/draft/resource/templates/views/show.html.erb
+++ b/lib/generators/draft/resource/templates/views/show.html.erb
@@ -1,8 +1,8 @@
 <h1>
-  <%= singular_table_name.humanize %> #<%%= @<%= singular_table_name %>.id %> details
+  <%= singular_table_name.humanize %> #<%%= @<%= singular_table_name %>_to_show.id %> details
 </h1>
 
-<a href="/<%= plural_table_name %>/<%%= @<%= singular_table_name %>.id %>/edit">
+<a href="/<%= plural_table_name %>/<%%= @<%= singular_table_name %>_to_show.id %>/edit">
   Edit <%= singular_table_name.humanize.downcase %>
 </a>
 
@@ -14,7 +14,7 @@
     <%= attribute.human_name %>
   </dt>
   <dd>
-    <%%= @<%= singular_table_name %>.<%= attribute.column_name %> %>
+    <%%= @<%= singular_table_name %>_to_show.<%= attribute.column_name %> %>
   </dd>
 
 <% end -%>
@@ -22,19 +22,19 @@
     Created at
   </dt>
   <dd>
-    <%%= time_ago_in_words(@<%= singular_table_name %>.created_at) %> ago
+    <%%= time_ago_in_words(@<%= singular_table_name %>_to_show.created_at) %> ago
   </dd>
 
   <dt>
     Updated at
   </dt>
   <dd>
-    <%%= time_ago_in_words(@<%= singular_table_name %>.updated_at) %> ago
+    <%%= time_ago_in_words(@<%= singular_table_name %>_to_show.updated_at) %> ago
   </dd>
 </dl>
 
 <% unless read_only? -%>
-<a href="/delete_<%= singular_table_name %>/<%%= @<%= singular_table_name %>.id %>" class="btn btn-default">
+<a href="/delete_<%= singular_table_name %>/<%%= @<%= singular_table_name %>_to_show.id %>" class="btn btn-default">
   Delete <%= singular_table_name.humanize.downcase %>
 </a>
 <% end -%>

--- a/lib/generators/draft/resource/templates/views/update_row.html.erb
+++ b/lib/generators/draft/resource/templates/views/update_row.html.erb
@@ -1,7 +1,7 @@
 <h1>You updated <%= singular_table_name.humanize.downcase %> #<%%= @<%= singular_table_name %>.id %>!</h1>
 
 <p>
-  <a href="/<%= plural_table_name.underscore %>/<%%= @<%= singular_table_name.underscore %>.id %>">
+  <a href="/<%= plural_table_name %>/<%%= @<%= singular_table_name %>.id %>">
     Click here
   </a>
 


### PR DESCRIPTION
 - Using strings as keys to the `params` hash following the heuristic:
   "If we could change it to 'zebra' on a whim, then use a string;
   otherwise use a symbol."
 - Making variable and input names longer and more pedantic.
 - Adding a non-error version of forms.