### PR TITLE
Add `draft:account` generator

### DIFF
--- a/lib/generators/draft/account/account_generator.rb
+++ b/lib/generators/draft/account/account_generator.rb
@@ -1,0 +1,196 @@
+require "rails/generators/named_base"
+
+module Draft
+  class AccountGenerator < Rails::Generators::NamedBase
+    source_root File.expand_path("../templates", __FILE__)
+
+    argument :attributes, type: :array, default: [],
+                                        banner: "field:type field:type"
+
+    include Rails::Generators::ResourceHelpers
+
+    def generate_required_attributes
+      unless attributes_has_password_digest?
+        password_digest = Rails::Generators::GeneratedAttribute.parse(["password_digest", :string, nil].compact.join(":"))
+        attributes.unshift(password_digest)
+      end
+      unless attributes_has_email?
+        email = Rails::Generators::GeneratedAttribute.parse(["email", :string, nil].compact.join(":"))
+        attributes.unshift(email)
+      end
+    end
+
+    def generate_model
+      invoke "draft:model", paramaterize_attributes
+      edit_model
+    end
+
+    def generate_routes
+      authentication_routes
+    end
+
+    def generate_before_actions
+      authentication_helpers
+    end
+
+    def generate_controller
+      template "controllers/sessions_controller.rb", "app/controllers/#{singular_table_name.underscore}_sessions_controller.rb"
+      template "controllers/controller.rb", "app/controllers/#{plural_table_name.underscore}_controller.rb"
+    end
+
+    def create_root_folder
+      empty_directory File.join("app/views", "#{singular_table_name.underscore}_sessions")
+      empty_directory File.join("app/views", "#{plural_table_name.underscore}")
+    end
+    
+    def generate_view_files
+      available_views.select{|filename| filename.include?("sign")}.each do |view|
+        filename = view_sessions_filename_with_extensions(view)
+        template filename, File.join("app/views/#{singular_table_name.underscore}_sessions", File.basename(filename))
+      end
+
+      available_views.reject{|filename| filename.include?("sign")}.each do |view|
+        filename = view_filename_with_extensions(view)
+        template filename, File.join("app/views/#{plural_table_name.underscore}", File.basename(filename))
+      end
+    end
+    
+    private
+
+    def authentication_routes
+      log :route, "Authentication routes"
+
+      route <<-RUBY.gsub(/^      /, "")
+
+        # Routes for signing up
+
+        match("/#{singular_table_name.underscore}_sign_up", { :controller => "#{plural_table_name.underscore}", :action => "new_registration_form", :via => "get"})
+        
+        # Routes for signing in
+        match("/#{singular_table_name.underscore}_sign_in", { :controller => "#{singular_table_name.underscore}_sessions", :action => "new_session_form", :via => "get"})
+        
+        match("/#{singular_table_name.underscore}_verify_credentials", { :controller => "#{singular_table_name.underscore}_sessions", :action => "add_cookie", :via => "post"})
+        
+        # Route for signing out
+        
+        match("/#{singular_table_name.underscore}_sign_out", { :controller => "#{singular_table_name.underscore}_sessions", :action => "remove_cookies", :via => "get"})
+        
+        # Route for creating account into database 
+
+        match("/post_#{singular_table_name.underscore}", { :controller => "#{plural_table_name.underscore}", :action => "create", :via => "post" })
+        
+        # Route for editing account
+        
+        match("/edit_#{singular_table_name.underscore}", { :controller => "#{plural_table_name.underscore}", :action => "edit_registration_form", :via => "get"})
+        
+        match("/patch_#{singular_table_name.underscore}", { :controller => "#{plural_table_name.underscore}", :action => "update", :via => "post"})
+        
+        # Route for removing an account
+        
+        match("/cancel_#{singular_table_name.underscore}_account", { :controller => "#{plural_table_name.underscore}", :action => "destroy", :via => "get"})
+
+
+        #------------------------------
+      RUBY
+    end
+
+    def authentication_helpers
+      log :controller, "Authentication before_actions"
+
+      application_controller <<-RUBY.gsub(/^      /, "")
+
+        before_action(:load_current_#{singular_table_name.underscore})
+        before_action(:force_#{singular_table_name.underscore}_sign_in)
+        
+        def load_current_#{singular_table_name.underscore}
+          the_id = session.fetch(:#{singular_table_name.underscore}_id)
+          @current_#{singular_table_name.underscore} = #{class_name.singularize}.where({ :id => the_id }).at(0)
+        end
+        
+        def force_#{singular_table_name.underscore}_sign_in
+          if @current_#{singular_table_name.underscore} == nil
+            redirect_to("/#{singular_table_name.underscore}_sign_in", { :notice => "You have to sign in first." })
+          end
+        end
+      RUBY
+    end
+
+    def edit_model
+      sentinel = /.*ApplicationRecord\n/
+      content = "  validates :email, :uniqueness => { :case_sensitive => false }\n"\
+        "  validates :email, :presence => true\n"\
+        "  has_secure_password\n"
+      if model_exists?
+        inside "app/models" do
+          insert_into_file "#{singular_table_name.underscore}.rb", content, after: sentinel
+        end
+      end
+    end
+
+    def route(routing_code)
+      sentinel = /\.routes\.draw do(?:\s*\|map\|)?\s*$/
+
+      inside "config" do
+        insert_into_file "routes.rb", routing_code, after: sentinel
+      end
+    end
+
+    def application_controller(app_code)
+      sentinel = /::Base$/
+
+      inside "app/controllers" do
+        insert_into_file "application_controller.rb", app_code, after: sentinel
+      end
+    end
+
+    def available_views
+      %w(sign_up sign_in edit_profile edit_profile_with_errors)
+    end
+
+    def view_filename_with_extensions(name)
+      filename = [name, :html, :erb].compact.join(".")
+      folders = ["views"]
+      filename = File.join(folders, filename) if folders.any?
+      filename
+    end
+
+    def view_sessions_filename_with_extensions(name)
+      filename = [name, :html, :erb].compact.join(".")
+      folders = ["views", "sessions"]
+      filename = File.join(folders, filename) if folders.any?
+      filename
+    end
+
+    def controller_filename_with_extensions(name)
+      filename = [name,:rb].compact.join(".")
+      folders = ["controllers"]
+      filename = File.join(folders, filename) if folders.any?
+      filename
+    end
+
+    def model_exists?
+      File.exist?(File.join(destination_root, model_path))
+    end
+
+    def model_path
+      @model_path ||= File.join("app", "models", "#{file_path}.rb")
+    end
+
+    def attributes_has_email?
+      attributes.any? { |attribute| attribute.column_name.include?("email") }
+    end
+
+    def attributes_has_password_digest?
+      attributes.any?{ |attribute| attribute.column_name.include?("password_digest") }
+    end
+
+    def paramaterize_attributes
+      array = [singular_table_name.underscore]
+      attributes.each do |attribute|
+        array.push(attribute.column_name + ":" + attribute.type.to_s)
+      end
+      array
+    end
+
+  end
+end

--- a/lib/generators/draft/account/templates/controllers/controller.rb
+++ b/lib/generators/draft/account/templates/controllers/controller.rb
@@ -1,0 +1,65 @@
+class <%= class_name.pluralize %>Controller < ApplicationController
+  skip_before_action(:force_<%= singular_table_name.underscore %>_sign_in, { :only => [:new_registration_form, :create] })
+  
+  def new_registration_form
+    render({ :template => "<%=singular_table_name.underscore %>_sessions/sign_up.html.erb" })
+  end
+
+  def create
+    @<%= singular_table_name.underscore %> = <%= class_name.singularize %>.new
+<% attributes.each do |attribute| -%>
+<% if attribute.field_type == :check_box -%>
+    @<%= singular_table_name.underscore %>.<%= attribute.column_name %> = params.fetch("<%= attribute.column_name %>_from_query", false)
+<% elsif attribute.column_name != "password_digest" -%>
+    @<%= singular_table_name.underscore %>.<%= attribute.column_name %> = params.fetch("<%= attribute.column_name %>_from_query")
+<% else -%>
+    @<%= singular_table_name.underscore %>.password = params.fetch("password_from_query")
+    @<%= singular_table_name.underscore %>.password_confirmation = params.fetch("password_confirmation_from_query")
+<% end -%>
+<% end -%>
+
+    save_status = @<%= singular_table_name.underscore %>.save
+
+    if save_status == true
+      session.store(:<%= singular_table_name.underscore %>_id,  @<%= singular_table_name.underscore %>.id)
+   
+      redirect_to("/", { :notice => "<%= singular_table_name.humanize %> account created successfully."})
+    else
+      redirect_to("/<%=singular_table_name.underscore %>_sign_up", { :alert => "<%= singular_table_name.humanize %> account failed to create successfully."})
+    end
+  end
+    
+  def edit_registration_form
+    render({ :template => "<%= plural_table_name.underscore %>/edit_profile.html.erb" })
+  end
+
+  def update
+    @<%= singular_table_name.underscore %> = @current_<%= singular_table_name.underscore %>
+<% attributes.each do |attribute| -%>
+<% if attribute.field_type == :check_box -%>
+    @<%= singular_table_name.underscore %>.<%= attribute.column_name %> = params.fetch("<%= attribute.column_name %>_from_query", false)
+<% elsif attribute.column_name != "password_digest" -%>
+    @<%= singular_table_name.underscore %>.<%= attribute.column_name %> = params.fetch("<%= attribute.column_name %>_from_query")
+<% else -%>
+    @<%= singular_table_name.underscore %>.password = params.fetch("password_from_query")
+    @<%= singular_table_name.underscore %>.password_confirmation = params.fetch("password_confirmation_from_query")
+<% end -%>
+<% end -%>
+    
+    if @<%= singular_table_name.underscore %>.valid?
+      @<%= singular_table_name.underscore %>.save
+
+      redirect_to("/", { :notice => "<%= singular_table_name.humanize %> account updated successfully."})
+    else
+      render({ :template => "<%= plural_table_name.underscore %>/edit_profile_with_errors.html.erb" })
+    end
+  end
+
+  def destroy
+    @current_<%= singular_table_name.underscore %>.destroy
+    reset_session
+    
+    redirect_to("/", { :notice => "<%= class_name.singularize %> account cancelled" })
+  end
+  
+end

--- a/lib/generators/draft/account/templates/controllers/sessions_controller.rb
+++ b/lib/generators/draft/account/templates/controllers/sessions_controller.rb
@@ -1,0 +1,34 @@
+class <%= class_name.singularize %>SessionsController < ApplicationController
+  skip_before_action(:force_<%= singular_table_name.underscore %>_sign_in, { :only => [:new_session_form, :add_cookie] })
+
+  def new_session_form
+    render({ :template => "<%=singular_table_name.underscore %>_sessions/sign_in.html.erb" })
+  end
+
+  def add_cookie
+    <%=singular_table_name.underscore %> = <%= class_name.singularize %>.where({ :email => params.fetch("email") }).at(0)
+    
+    the_supplied_password = params.fetch(:password)
+    
+    if <%=singular_table_name.underscore %> != nil
+      are_they_legit = <%=singular_table_name.underscore %>.authenticate(the_supplied_password)
+    
+      if are_they_legit == false
+        redirect_to("/sign_in", { :alert => "Password incorrect." })
+      else
+        session.store(:<%=singular_table_name.underscore %>_id, <%=singular_table_name.underscore %>.id)
+      
+        redirect_to("/", { :notice => "Signed in successfully." })
+      end
+    else
+      redirect_to("/<%=singular_table_name.underscore %>_sign_in", { :alert => "There's no <%=singular_table_name.underscore %> account with that email address." })
+    end
+  end
+
+  def remove_cookies
+    reset_session
+
+    redirect_to("/", { :notice => "Signed out successfully." })
+  end
+ 
+end

--- a/lib/generators/draft/account/templates/views/edit_profile.html.erb
+++ b/lib/generators/draft/account/templates/views/edit_profile.html.erb
@@ -1,0 +1,38 @@
+<div >
+  <h5>
+    Edit <%= class_name.titleize %> Account
+  </h5>
+
+  <div>
+    <form action="/patch_<%= singular_table_name.underscore %>" method="post">
+<% attributes.each do |attribute| -%>
+<% if attribute.column_name != "password_digest" -%>
+      <div>
+        <label for="<%= attribute.column_name %>_box"><%= attribute.column_name.humanize %></label>
+<% if attribute.field_type == :text_area -%>
+        <textarea id="<%= attribute.column_name %>_box" name="<%= attribute.column_name %>_from_query" rows="3"><%%= @current_<%= singular_table_name %>.<%= attribute.column_name %> %></textarea> 
+<% elsif attribute.field_type == :check_box -%>
+        <input id="<%= attribute.column_name %>_box" name="<%= attribute.column_name %>_from_query" type="checkbox" value="1">
+<% else -%>
+        <input id="<%= attribute.column_name %>_box" name="<%= attribute.column_name %>_from_query" value="<%%= @current_<%= singular_table_name.underscore %>.<%= attribute.column_name %> %>">
+<% end -%>
+      </div>
+<% end -%>
+<% end -%>
+
+      <div>
+        <label for="password_box">Password</label>
+        <input id="password_box" name="password_from_query" placeholder="Choose a password..." type="password">
+      </div>
+    
+      <div>
+        <label for="password_confirmation_box">Password Confirmation</label>
+        <input id="password_confirmation_box" name="password_confirmation_from_query" placeholder="Confirm your password..." type="password">
+      </div>
+
+      <button>
+        Update account
+      </button>
+    </form>
+  </div>
+</div>

--- a/lib/generators/draft/account/templates/views/edit_profile_with_errors.html.erb
+++ b/lib/generators/draft/account/templates/views/edit_profile_with_errors.html.erb
@@ -1,0 +1,44 @@
+<div >
+  <h5>
+    Edit <%= class_name.titleize %> Account
+  </h5>
+
+  <%% if @<%= singular_table_name %>.errors.any? %>
+  <%% @<%= singular_table_name %>.errors.full_messages.each do |message| %>
+    <div class="alert">
+      <%%= message %>
+    </div>
+  <%% end %>
+  <%% end %>
+  <div>
+    <form action="/patch_<%= singular_table_name.underscore %>" method="post">
+      <% attributes.each do |attribute| -%>
+        <% if attribute.column_name != "password_digest" %>
+      <div>
+        <label for="<%= attribute.column_name %>_box"><%= attribute.column_name.humanize %></label>
+          <% if attribute.field_type == :text_area %>
+        <textarea id="<%= attribute.column_name %>_box" name="<%= attribute.column_name %>_from_query" rows="3"><%%= @current_<%= singular_table_name %>.<%= attribute.column_name %> %></textarea> 
+          <% elsif attribute.field_type == :check_box %>
+        <input id="<%= attribute.column_name %>_box" name="<%= attribute.column_name %>_from_query" type="checkbox" value="1">
+          <% else %>
+        <input id="<%= attribute.column_name %>_box" name="<%= attribute.column_name %>_from_query" value="<%%= @current_<%= singular_table_name.underscore %>.<%= attribute.column_name %> %>">
+          <% end %>
+      </div>
+        <% end -%>
+      <% end %>
+      <div>
+        <label for="password_box">Password</label>
+        <input id="password_box" name="password_from_query" placeholder="Choose a new password..." type="password">
+      </div>
+    
+      <div>
+        <label for="password_confirmation_box">Password Confirmation</label>
+        <input id="password_confirmation_box" name="password_confirmation_from_query" placeholder="Confirm your new password..." type="password">
+      </div>
+
+      <button>
+        Update account
+      </button>
+    </form>
+  </div>
+</div>

--- a/lib/generators/draft/account/templates/views/sessions/sign_in.html.erb
+++ b/lib/generators/draft/account/templates/views/sessions/sign_in.html.erb
@@ -1,0 +1,23 @@
+<h1>Sign in</h1>
+
+<form action="/<%= singular_table_name.underscore %>_verify_credentials" method="post">
+  <div>
+    <label for="email_box">Email</label>
+    <input id="email_box" name="email_from_query" placeholder="Enter your email..." type="text">
+  </div>
+
+  <div>
+    <label for="password_box">Password</label>
+    <input id="password_box" name="password_from_query" placeholder="Enter your password..." type="password">
+  </div>
+
+  <button>
+    Sign in
+  </button>
+</form>
+
+<hr>
+
+<p>
+  Or, <a href="/<%= singular_table_name.underscore %>_sign_up">Sign up</a> instead.
+</p>

--- a/lib/generators/draft/account/templates/views/sessions/sign_up.html.erb
+++ b/lib/generators/draft/account/templates/views/sessions/sign_up.html.erb
@@ -1,0 +1,43 @@
+<h1>Sign up</h1>
+
+<form action="/post_<%= singular_table_name.underscore %>" method="post">
+
+  <div>
+    <label for="email_box">Email</label>
+    <input id="email_box" name="email_from_query" placeholder="Choose a email..." type="text">
+  </div>
+  <% attributes.each do |attribute| -%>
+  <% if attribute.column_name != "password_digest" && attribute.column_name != "email" -%>     
+  <div>
+    <label for="<%= attribute.column_name %>_box"><%= attribute.column_name.humanize %></label>
+  <%- if attribute.field_type == :check_box -%>
+    <input id="<%= attribute.column_name %>_box" name="<%= attribute.column_name %>_from_query" type="checkbox">
+  <%- elsif attribute.field_type == :text_area -%>
+    <textarea id="<%= attribute.column_name %>_box" name="<%= attribute.column_name %>_from_query" rows="3"></textarea>
+  <%- else -%>      
+    <input type="text" id="<%= attribute.column_name %>_box" name="<%= attribute.column_name %>_from_query">
+  <%- end -%>
+  </div>
+  <%- end -%>
+  <% end -%>
+  
+  <div>
+    <label for="password_box">Password</label>
+    <input id="password_box" name="password_from_query" placeholder="Choose a password..." type="password">
+  </div>
+
+  <div>
+    <label for="password_confirmation_box">Password Confirmation</label>
+    <input id="password_confirmation_box" name="password_confirmation_from_query" placeholder="Confirm your password..." type="password">
+  </div>
+
+  <button>
+    Sign up
+  </button>
+</form>
+
+<hr>
+
+<p>
+  Or, <a href="/<%= singular_table_name.underscore %>_sign_in">Sign in</a> instead.
+</p>


### PR DESCRIPTION
Resolve #65 

This branch adds the `draft:account` generator.

Creates:
- all authentication routes
- adds `has_secure_password` and basic validations model
- `@current_[MODEL_NAME]` helper in `application_controller.rb`
- `before_action`s to force sign in from anyone using the app and load the current signed in person
- a `[MODEL_NAME]_session_controller.rb` to house all the authentication related actions
- a `[MODEL_NAME]_controller.rb` to house all CRUD actions for model that aren't authentication related
- Views for `sign_up`, `sign_in`, and `edit_account` actions

This generator will add an `email` and `password_digest` column **only if** if you don't pass them in.

Add this to your `Gemfile`:
```ruby
gem 'draft_generators', github: 'firstdraft/draft_generators', branch: "jw-add-account-generator"
```

Example usage:
```sh
rails g draft:account user username:string bio:text private:boolean
```

Another example usage:
```sh
rails g draft:account member email:string password_digest:string bio:text private:boolean
```