### PR TITLE
Prepopulate checkbox on edit account forms

### DIFF
--- a/lib/generators/draft/account/templates/views/authentication/edit_profile.html.erb
+++ b/lib/generators/draft/account/templates/views/authentication/edit_profile.html.erb
@@ -12,7 +12,7 @@
 <% if attribute.field_type == :text_area -%>
         <textarea id="<%= attribute.column_name %>_box" name="query_<%= attribute.column_name %>" rows="3"><%%= @current_<%= singular_table_name %>.<%= attribute.column_name %> %></textarea> 
 <% elsif attribute.field_type == :check_box -%>
-        <input id="<%= attribute.column_name %>_box" name="query_<%= attribute.column_name %>" type="checkbox" value="1">
+        <input id="<%= attribute.column_name %>_box" name="query_<%= attribute.column_name %>" type="checkbox" value="1" <%%= "checked" if @current_<%= singular_table_name %>.<%= attribute.column_name %> %>>
 <% else -%>
         <input id="<%= attribute.column_name %>_box" name="query_<%= attribute.column_name %>" value="<%%= @current_<%= singular_table_name.underscore %>.<%= attribute.column_name %> %>">
 <% end -%>

--- a/lib/generators/draft/account/templates/views/authentication/edit_profile_with_errors.html.erb
+++ b/lib/generators/draft/account/templates/views/authentication/edit_profile_with_errors.html.erb
@@ -19,7 +19,7 @@
           <% if attribute.field_type == :text_area %>
         <textarea id="<%= attribute.column_name %>_box" name="query_<%= attribute.column_name %>" rows="3"><%%= @current_<%= singular_table_name %>.<%= attribute.column_name %> %></textarea> 
           <% elsif attribute.field_type == :check_box %>
-        <input id="<%= attribute.column_name %>_box" name="query_<%= attribute.column_name %>" type="checkbox" value="1">
+        <input id="<%= attribute.column_name %>_box" name="query_<%= attribute.column_name %>" type="checkbox" value="1" <%%= "checked" if @current_<%= singular_table_name %>.<%= attribute.column_name %> %>>
           <% else %>
         <input id="<%= attribute.column_name %>_box" name="query_<%= attribute.column_name %>" value="<%%= @current_<%= singular_table_name.underscore %>.<%= attribute.column_name %> %>">
           <% end %>


### PR DESCRIPTION
Resolves https://github.com/firstdraft/draft_generators/issues/80

Generates the conditional so that checkboxes are properly pre-populated.

```erb
<input id="private_box" name="query_private" type="checkbox" value="1" <%= "checked" if @current_user.private %>>
```

To test, add

```ruby
gem 'draft_generators', github: 'firstdraft/draft_generators', branch: 'jw-prepopulate-edit-checkbox-on-account'
```

to your Gemfile, `bundle` and `rails g draft:account coach active:boolean name:string`