### PR TITLE
Pm resource variable naming

### DIFF
--- a/lib/generators/draft/resource/templates/controllers/controller.rb
+++ b/lib/generators/draft/resource/templates/controllers/controller.rb
@@ -1,12 +1,12 @@
 class <%= plural_table_name.camelize %>Controller < ApplicationController
   def index
-    @<%= plural_table_name.underscore %> = <%= class_name.singularize %>.all
+    @list_of_<%= plural_table_name.underscore %> = <%= class_name.singularize %>.all
 
     render("<%= singular_table_name.underscore %>_templates/index.html.erb")
   end
 
   def show
-    @<%= singular_table_name.underscore %> = <%= class_name.singularize %>.find(params.fetch("id_to_display"))
+    @the_<%= singular_table_name.underscore %> = <%= class_name.singularize %>.find(params.fetch("id_to_display"))
 
     render("<%= singular_table_name.underscore %>_templates/show.html.erb")
   end
@@ -18,10 +18,10 @@ class <%= plural_table_name.camelize %>Controller < ApplicationController
   end
 
   def create_row
-    @<%= singular_table_name.underscore %> = <%= class_name.singularize %>.new
+    @the_<%= singular_table_name.underscore %> = <%= class_name.singularize %>.new
 
 <% attributes.each do |attribute| -%>
-    @<%= singular_table_name.underscore %>.<%= attribute.column_name %> = params.fetch("<%= attribute.column_name %>")
+    @the_<%= singular_table_name.underscore %>.<%= attribute.column_name %> = params.fetch("<%= attribute.column_name %>")
 <% end -%>
 
 <% unless skip_validation_alerts? -%>
@@ -46,16 +46,16 @@ class <%= plural_table_name.camelize %>Controller < ApplicationController
   end
 
   def edit_form
-    @<%= singular_table_name.underscore %> = <%= class_name.singularize %>.find(params.fetch("prefill_with_id"))
+    @the_<%= singular_table_name.underscore %> = <%= class_name.singularize %>.find(params.fetch("prefill_with_id"))
 
     render("<%= singular_table_name.underscore %>_templates/edit_form.html.erb")
   end
 
   def update_row
-    @<%= singular_table_name.underscore %> = <%= class_name.singularize %>.find(params.fetch("id_to_modify"))
+    @the_<%= singular_table_name.underscore %> = <%= class_name.singularize %>.find(params.fetch("id_to_modify"))
 
 <% attributes.each do |attribute| -%>
-    @<%= singular_table_name.underscore %>.<%= attribute.column_name %> = params.fetch("<%= attribute.column_name %>")
+    @the_<%= singular_table_name.underscore %>.<%= attribute.column_name %> = params.fetch("<%= attribute.column_name %>")
 <% end -%>
 
 <% unless skip_validation_alerts? -%>

--- a/lib/generators/draft/resource/templates/controllers/controller.rb
+++ b/lib/generators/draft/resource/templates/controllers/controller.rb
@@ -59,10 +59,10 @@ class <%= plural_table_name.camelize %>Controller < ApplicationController
 <% end -%>
 
 <% unless skip_validation_alerts? -%>
-    if @<%= singular_table_name.underscore %>.valid?
-      @<%= singular_table_name.underscore %>.save
+    if @the_<%= singular_table_name.underscore %>.valid?
+      @the_<%= singular_table_name.underscore %>.save
 
-      redirect_to("/<%= @plural_table_name.underscore %>/#{@<%= singular_table_name.underscore %>.id}", :notice => "<%= singular_table_name.humanize %> updated successfully.")
+      redirect_to("/<%= @plural_table_name.underscore %>/#{@the_<%= singular_table_name.underscore %>.id}", :notice => "<%= singular_table_name.humanize %> updated successfully.")
     else
       render("<%= singular_table_name.underscore %>_templates/edit_form_with_errors.html.erb")
     end
@@ -78,9 +78,9 @@ class <%= plural_table_name.camelize %>Controller < ApplicationController
   end
 
   def destroy_row
-    @<%= singular_table_name.underscore %> = <%= class_name.singularize %>.find(params.fetch("id_to_remove"))
+    @the_<%= singular_table_name.underscore %> = <%= class_name.singularize %>.find(params.fetch("id_to_remove"))
 
-    @<%= singular_table_name.underscore %>.destroy
+    @the_<%= singular_table_name.underscore %>.destroy
 
 <% unless skip_validation_alerts? -%>
     redirect_to("/<%= @plural_table_name.underscore %>", :notice => "<%= singular_table_name.humanize %> deleted successfully.")

--- a/lib/generators/draft/resource/templates/controllers/controller.rb
+++ b/lib/generators/draft/resource/templates/controllers/controller.rb
@@ -25,15 +25,15 @@ class <%= plural_table_name.camelize %>Controller < ApplicationController
 <% end -%>
 
 <% unless skip_validation_alerts? -%>
-    if @<%= singular_table_name.underscore %>.valid?
-      @<%= singular_table_name.underscore %>.save
+    if @the_<%= singular_table_name.underscore %>.valid?
+      @the_<%= singular_table_name.underscore %>.save
 
       redirect_back(:fallback_location => "/<%= @plural_table_name.underscore %>", :notice => "<%= singular_table_name.humanize %> created successfully.")
     else
       render("<%= singular_table_name.underscore %>_templates/new_form_with_errors.html.erb")
     end
 <% else -%>
-    @<%= singular_table_name.underscore %>.save
+    @the_<%= singular_table_name.underscore %>.save
 
 <% unless skip_redirect? -%>
     redirect_to("/<%= @plural_table_name.underscore %>")

--- a/lib/generators/draft/resource/templates/views/index.html.erb
+++ b/lib/generators/draft/resource/templates/views/index.html.erb
@@ -51,13 +51,13 @@
       <%% @list_of_<%= plural_table_name %>.each do |one_<%= singular_table_name %>| %>
       <tr>
 <% if with_sentinels? -%>
-        <!-- Display <%= singular_table_name %>.id start -->
+        <!-- Display one_<%= singular_table_name %>.id start -->
 <% end -%>
         <td>
-          <%%= <%= singular_table_name %>.id %>
+          <%%= one_<%= singular_table_name %>.id %>
         </td>
 <% if with_sentinels? -%>
-        <!-- Display <%= singular_table_name %>.id end -->
+        <!-- Display one_<%= singular_table_name %>.id end -->
 <% end -%>
 
 <% attributes.each do |attribute| -%>

--- a/lib/generators/draft/resource/templates/views/index.html.erb
+++ b/lib/generators/draft/resource/templates/views/index.html.erb
@@ -48,7 +48,7 @@
         </th>
       </tr>
 
-      <%% @<%= plural_table_name %>.each do |<%= singular_table_name %>| %>
+      <%% @list_of_<%= plural_table_name %>.each do |one_<%= singular_table_name %>| %>
       <tr>
 <% if with_sentinels? -%>
         <!-- Display <%= singular_table_name %>.id start -->

--- a/lib/generators/draft/resource/templates/views/index.html.erb
+++ b/lib/generators/draft/resource/templates/views/index.html.erb
@@ -62,36 +62,36 @@
 
 <% attributes.each do |attribute| -%>
 <% if with_sentinels? -%>
-        <!-- Display <%= singular_table_name %>.<%= attribute.column_name %> start -->
+        <!-- Display one_<%= singular_table_name %>.<%= attribute.column_name %> start -->
 <% end -%>
         <td>
-          <%%= <%= singular_table_name %>.<%= attribute.column_name %> %>
+          <%%= one_<%= singular_table_name %>.<%= attribute.column_name %> %>
         </td>
 <% if with_sentinels? -%>
-        <!-- Display <%= singular_table_name %>.<%= attribute.column_name %> end -->
+        <!-- Display one_<%= singular_table_name %>.<%= attribute.column_name %> end -->
 <% end -%>
 
 <% end -%>
 <% if with_sentinels? -%>
-        <!-- Display <%= singular_table_name %>.created_at start -->
+        <!-- Display one_<%= singular_table_name %>.created_at start -->
 <% end -%>
         <td>
-          <%%= time_ago_in_words(<%= singular_table_name %>.created_at) %> ago
+          <%%= time_ago_in_words(one_<%= singular_table_name %>.created_at) %> ago
         </td>
 <% if with_sentinels? -%>
-        <!-- Display <%= singular_table_name %>.created_at end -->
+        <!-- Display one_<%= singular_table_name %>.created_at end -->
 
-        <!-- Display <%= singular_table_name %>.updated_at start -->
+        <!-- Display one_<%= singular_table_name %>.updated_at start -->
 <% end -%>
         <td>
-          <%%= time_ago_in_words(<%= singular_table_name %>.updated_at) %> ago
+          <%%= time_ago_in_words(one_<%= singular_table_name %>.updated_at) %> ago
         </td>
 <% if with_sentinels? -%>
-        <!-- Display <%= singular_table_name %>.updated_at end -->
+        <!-- Display one_<%= singular_table_name %>.updated_at end -->
 <% end -%>
 
         <td>
-          <a href="/<%= plural_table_name %>/<%%= <%= singular_table_name %>.id %>">
+          <a href="/<%= plural_table_name %>/<%%= one_<%= singular_table_name %>.id %>">
             Show details
           </a>
         </td>

--- a/lib/generators/draft/resource/templates/views/show.html.erb
+++ b/lib/generators/draft/resource/templates/views/show.html.erb
@@ -47,7 +47,7 @@
       <!-- Display <%= attribute.column_name %> start -->
 <% end -%>
       <dd>
-        <%%= @<%= singular_table_name %>.<%= attribute.column_name %> %>
+        <%%= @the<%= singular_table_name %>.<%= attribute.column_name %> %>
       </dd>
 <% if with_sentinels? -%>
       <!-- Display <%= attribute.column_name %> end -->

--- a/lib/generators/draft/resource/templates/views/show.html.erb
+++ b/lib/generators/draft/resource/templates/views/show.html.erb
@@ -1,7 +1,7 @@
 <div class="row mb-3">
   <div class="col-md-8 offset-md-2">
     <h1>
-      <%= singular_table_name.humanize %> #<%%= @<%= singular_table_name %>.id %> details
+      <%= singular_table_name.humanize %> #<%%= @the_<%= singular_table_name %>.id %> details
     </h1>
 
     <div class="row mb-3">
@@ -15,7 +15,7 @@
       <!-- Edit link <%= singular_table_name %> start -->
 <% end -%>
       <div class="col">
-        <a href="/<%= plural_table_name %>/<%%= @<%= singular_table_name %>.id %>/edit" class="btn btn-block btn-outline-secondary">
+        <a href="/<%= plural_table_name %>/<%%= @the_<%= singular_table_name %>.id %>/edit" class="btn btn-block btn-outline-secondary">
           Edit <%= singular_table_name.humanize.downcase %>
         </a>
       </div>
@@ -28,7 +28,7 @@
       <!-- Delete link <%= singular_table_name %> start -->
 <% end -%>
       <div class="col">
-        <a href="/delete_<%= singular_table_name %>/<%%= @<%= singular_table_name %>.id %>" class="btn btn-block btn-outline-secondary">
+        <a href="/delete_<%= singular_table_name %>/<%%= @the_<%= singular_table_name %>.id %>" class="btn btn-block btn-outline-secondary">
           Delete <%= singular_table_name.humanize.downcase %>
         </a>
       </div>
@@ -61,7 +61,7 @@
       <!-- Display created_at start -->
 <% end -%>
       <dd>
-        <%%= time_ago_in_words(@<%= singular_table_name %>.created_at) %> ago
+        <%%= time_ago_in_words(@the_<%= singular_table_name %>.created_at) %> ago
       </dd>
 <% if with_sentinels? -%>
       <!-- Display created_at end -->
@@ -74,7 +74,7 @@
       <!-- Display updated_at start -->
 <% end -%>
       <dd>
-        <%%= time_ago_in_words(@<%= singular_table_name %>.updated_at) %> ago
+        <%%= time_ago_in_words(@the_<%= singular_table_name %>.updated_at) %> ago
       </dd>
 <% if with_sentinels? -%>
       <!-- Display updated_at end -->

--- a/lib/generators/draft/resource/templates/views/show.html.erb
+++ b/lib/generators/draft/resource/templates/views/show.html.erb
@@ -44,13 +44,13 @@
         <%= attribute.human_name %>
       </dt>
 <% if with_sentinels? -%>
-      <!-- Display <%= attribute.column_name %> start -->
+      <!-- Display the_<%= attribute.column_name %> start -->
 <% end -%>
       <dd>
-        <%%= @the<%= singular_table_name %>.<%= attribute.column_name %> %>
+        <%%= @the_<%= singular_table_name %>.<%= attribute.column_name %> %>
       </dd>
 <% if with_sentinels? -%>
-      <!-- Display <%= attribute.column_name %> end -->
+      <!-- Display the_<%= attribute.column_name %> end -->
 <% end -%>
 
 <% end -%>


### PR DESCRIPTION
I edited the draft generators to follow the convention talked about in issue #86.  I went with `the_class` for a single record and `list_of_classes` for a group of records.  The one change that I made was to go with `one_record` in place of `a_record` so we wouldn't have to deal with an "a" or "an" situation.  I did find a method we could use to address this if we agree that `a` is better than `one`.  