### PR TITLE
Pm resource variable off winter

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ group :development do
   gem "bundler", "~> 1.0"
   gem "juwelier", "~> 2.1.0"
   gem "simplecov", ">= 0"
-  gem 'indefinite_article'
+  
 end
 
 gem 'indefinite_article'

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 source "https://rubygems.org"
+git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 # Add dependencies required to use your gem here.
 # Example:
 #   gem "activesupport", ">= 2.3.5"

--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ group :development do
   gem "bundler", "~> 1.0"
   gem "juwelier", "~> 2.1.0"
   gem "simplecov", ">= 0"
+  gem 'indefinite_article'
 end
 
 gem 'indefinite_article'

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,4 @@
 source "https://rubygems.org"
-git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 # Add dependencies required to use your gem here.
 # Example:
 #   gem "activesupport", ">= 2.3.5"

--- a/Gemfile
+++ b/Gemfile
@@ -13,4 +13,5 @@ group :development do
   gem "simplecov", ">= 0"
 end
 
+gem 'indefinite_article'
 gem 'devise'

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,6 @@ group :development do
   gem "bundler", "~> 1.0"
   gem "juwelier", "~> 2.1.0"
   gem "simplecov", ">= 0"
-  
 end
 
 gem 'indefinite_article'

--- a/draft_generators.gemspec
+++ b/draft_generators.gemspec
@@ -95,6 +95,7 @@ Gem::Specification.new do |s|
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<devise>.freeze, [">= 0"])
+      s.add_runtime_dependency(%q<indefinite_article>.freeze, [">= 0"])
       s.add_development_dependency(%q<rspec>.freeze, ["~> 3.5.0"])
       s.add_development_dependency(%q<rdoc>.freeze, ["~> 3.12"])
       s.add_development_dependency(%q<bundler>.freeze, ["~> 1.0"])

--- a/lib/draft_generators.rb
+++ b/lib/draft_generators.rb
@@ -3,6 +3,7 @@
 require "devise_customization_service"
 require "rails_tag_service"
 require "devise"
+require 'indefinite_article'
 
 module DraftGenerators
 end

--- a/lib/draft_generators.rb
+++ b/lib/draft_generators.rb
@@ -3,7 +3,7 @@
 require "devise_customization_service"
 require "rails_tag_service"
 require "devise"
-require 'indefinite_article'
+require "indefinite_article"
 
 module DraftGenerators
 end

--- a/lib/generators/draft/resource/resource_generator.rb
+++ b/lib/generators/draft/resource/resource_generator.rb
@@ -1,3 +1,5 @@
+require 'indefinite_article'
+
 module Draft
   class ResourceGenerator < Rails::Generators::NamedBase
     source_root File.expand_path("../templates", __FILE__)

--- a/lib/generators/draft/resource/resource_generator.rb
+++ b/lib/generators/draft/resource/resource_generator.rb
@@ -1,5 +1,3 @@
-require 'indefinite_article'
-
 module Draft
   class ResourceGenerator < Rails::Generators::NamedBase
     source_root File.expand_path("../templates", __FILE__)

--- a/lib/generators/draft/resource/templates/controllers/controller.rb
+++ b/lib/generators/draft/resource/templates/controllers/controller.rb
@@ -50,7 +50,7 @@ class <%= plural_table_name.camelize %>Controller < ApplicationController
 <% if attribute.field_type == :check_box -%>
     @the_<%= singular_table_name.underscore %>.<%= attribute.column_name %> = params.fetch("query_<%= attribute.column_name %>", false)
 <% else -%>
-    @<%= singular_table_name.underscore %>.<%= attribute.column_name %> = params.fetch("query_<%= attribute.column_name %>")
+    @the_<%= singular_table_name.underscore %>.<%= attribute.column_name %> = params.fetch("query_<%= attribute.column_name %>")
 <% end -%>
 <% end -%>
 

--- a/lib/generators/draft/resource/templates/controllers/controller.rb
+++ b/lib/generators/draft/resource/templates/controllers/controller.rb
@@ -57,15 +57,15 @@ class <%= plural_table_name.camelize %>Controller < ApplicationController
 <% unless skip_validation_alerts? -%>
     if @the_<%= singular_table_name.underscore %>.valid?
       @the_<%= singular_table_name.underscore %>.save
-      redirect_to("/<%= @plural_table_name.underscore %>/#{@<%= singular_table_name.underscore %>.id}", { :notice => "<%= singular_table_name.humanize %> updated successfully."} )
+      redirect_to("/<%= @plural_table_name.underscore %>/#{@the<%= singular_table_name.underscore %>.id}", { :notice => "<%= singular_table_name.humanize %> updated successfully."} )
     else
-      redirect_to("/<%= @plural_table_name.underscore %>/#{@<%= singular_table_name.underscore %>.id}", { :alert => "<%= singular_table_name.humanize %> failed to update successfully." })
+      redirect_to("/<%= @plural_table_name.underscore %>/#{@the<%= singular_table_name.underscore %>.id}", { :alert => "<%= singular_table_name.humanize %> failed to update successfully." })
     end
 <% else -%>
     @the_<%= singular_table_name.underscore %>.save
 
 <% unless skip_redirect? -%>
-    redirect_to("/<%= @plural_table_name.underscore %>/#{@<%= singular_table_name.underscore %>.id}")
+    redirect_to("/<%= @plural_table_name.underscore %>/#{@the<%= singular_table_name.underscore %>.id}")
 <% else -%>
       render({ :template => "<%= plural_table_name.underscore %>/show.html.erb" })
   <% end -%>

--- a/lib/generators/draft/resource/templates/controllers/controller.rb
+++ b/lib/generators/draft/resource/templates/controllers/controller.rb
@@ -18,7 +18,7 @@ class <%= plural_table_name.camelize %>Controller < ApplicationController
 <% if attribute.field_type == :check_box -%>
     @the_<%= singular_table_name.underscore %>.<%= attribute.column_name %> = params.fetch("query_<%= attribute.column_name %>", false)
 <% else -%>
-    @<%= singular_table_name.underscore %>.<%= attribute.column_name %> = params.fetch("query_<%= attribute.column_name %>")
+    @the_<%= singular_table_name.underscore %>.<%= attribute.column_name %> = params.fetch("query_<%= attribute.column_name %>")
 <% end -%>
 <% end -%>
 

--- a/lib/generators/draft/resource/templates/controllers/controller.rb
+++ b/lib/generators/draft/resource/templates/controllers/controller.rb
@@ -1,36 +1,36 @@
 class <%= plural_table_name.camelize %>Controller < ApplicationController
   def index
-    @<%= plural_table_name.underscore %> = <%= class_name.singularize %>.all.order({ :created_at => :desc })
+    @list_of_<%= plural_table_name.underscore %> = <%= class_name.singularize %>.all.order({ :created_at => :desc })
 
     render({ :template => "<%= plural_table_name.underscore %>/index.html.erb" })
   end
 
   def show
     the_id = params.fetch("path_id")
-    @<%= singular_table_name.underscore %> = <%= class_name.singularize %>.where({ :id => the_id }).at(0)
+    @the_<%= singular_table_name.underscore %> = <%= class_name.singularize %>.where({ :id => the_id }).at(0)
 
     render({ :template => "<%= plural_table_name.underscore %>/show.html.erb" })
   end
 
   def create
-    @<%= singular_table_name.underscore %> = <%= class_name.singularize %>.new
+    @the_<%= singular_table_name.underscore %> = <%= class_name.singularize %>.new
 <% attributes.each do |attribute| -%>
 <% if attribute.field_type == :check_box -%>
-    @<%= singular_table_name.underscore %>.<%= attribute.column_name %> = params.fetch("query_<%= attribute.column_name %>", false)
+    @the_<%= singular_table_name.underscore %>.<%= attribute.column_name %> = params.fetch("query_<%= attribute.column_name %>", false)
 <% else -%>
     @<%= singular_table_name.underscore %>.<%= attribute.column_name %> = params.fetch("query_<%= attribute.column_name %>")
 <% end -%>
 <% end -%>
 
 <% unless skip_validation_alerts? -%>
-    if @<%= singular_table_name.underscore %>.valid?
-      @<%= singular_table_name.underscore %>.save
+    if @the_<%= singular_table_name.underscore %>.valid?
+      @the_<%= singular_table_name.underscore %>.save
       redirect_to("/<%= plural_table_name.underscore %>", { :notice => "<%= singular_table_name.humanize %> created successfully." })
     else
       redirect_to("/<%= plural_table_name.underscore %>", { :notice => "<%= singular_table_name.humanize %> failed to create successfully." })
     end
 <% else -%>
-    @<%= singular_table_name.underscore %>.save
+    @the_<%= singular_table_name.underscore %>.save
 
 <% unless skip_redirect? -%>
     redirect_to("/<%= @plural_table_name.underscore %>")
@@ -44,25 +44,25 @@ class <%= plural_table_name.camelize %>Controller < ApplicationController
 
   def update
     the_id = params.fetch("path_id")
-    @<%= singular_table_name.underscore %> = <%= class_name.singularize %>.where({ :id => the_id }).at(0)
+    @the_<%= singular_table_name.underscore %> = <%= class_name.singularize %>.where({ :id => the_id }).at(0)
 
 <% attributes.each do |attribute| -%>
 <% if attribute.field_type == :check_box -%>
-    @<%= singular_table_name.underscore %>.<%= attribute.column_name %> = params.fetch("query_<%= attribute.column_name %>", false)
+    @the_<%= singular_table_name.underscore %>.<%= attribute.column_name %> = params.fetch("query_<%= attribute.column_name %>", false)
 <% else -%>
     @<%= singular_table_name.underscore %>.<%= attribute.column_name %> = params.fetch("query_<%= attribute.column_name %>")
 <% end -%>
 <% end -%>
 
 <% unless skip_validation_alerts? -%>
-    if @<%= singular_table_name.underscore %>.valid?
-      @<%= singular_table_name.underscore %>.save
+    if @the_<%= singular_table_name.underscore %>.valid?
+      @the_<%= singular_table_name.underscore %>.save
       redirect_to("/<%= @plural_table_name.underscore %>/#{@<%= singular_table_name.underscore %>.id}", { :notice => "<%= singular_table_name.humanize %> updated successfully."} )
     else
       redirect_to("/<%= @plural_table_name.underscore %>/#{@<%= singular_table_name.underscore %>.id}", { :alert => "<%= singular_table_name.humanize %> failed to update successfully." })
     end
 <% else -%>
-    @<%= singular_table_name.underscore %>.save
+    @the_<%= singular_table_name.underscore %>.save
 
 <% unless skip_redirect? -%>
     redirect_to("/<%= @plural_table_name.underscore %>/#{@<%= singular_table_name.underscore %>.id}")
@@ -74,9 +74,9 @@ class <%= plural_table_name.camelize %>Controller < ApplicationController
 
   def destroy
     the_id = params.fetch("path_id")
-    @<%= singular_table_name.underscore %> = <%= class_name.singularize %>.where({ :id => the_id }).at(0)
+    @the_<%= singular_table_name.underscore %> = <%= class_name.singularize %>.where({ :id => the_id }).at(0)
 
-    @<%= singular_table_name.underscore %>.destroy
+    @the_<%= singular_table_name.underscore %>.destroy
 
 <% unless skip_validation_alerts? -%>
     redirect_to("/<%= @plural_table_name.underscore %>", { :notice => "<%= singular_table_name.humanize %> deleted successfully."} )

--- a/lib/generators/draft/resource/templates/controllers/controller.rb
+++ b/lib/generators/draft/resource/templates/controllers/controller.rb
@@ -57,15 +57,15 @@ class <%= plural_table_name.camelize %>Controller < ApplicationController
 <% unless skip_validation_alerts? -%>
     if @the_<%= singular_table_name.underscore %>.valid?
       @the_<%= singular_table_name.underscore %>.save
-      redirect_to("/<%= @plural_table_name.underscore %>/#{@the<%= singular_table_name.underscore %>.id}", { :notice => "<%= singular_table_name.humanize %> updated successfully."} )
+      redirect_to("/<%= @plural_table_name.underscore %>/#{@the_<%= singular_table_name.underscore %>.id}", { :notice => "<%= singular_table_name.humanize %> updated successfully."} )
     else
-      redirect_to("/<%= @plural_table_name.underscore %>/#{@the<%= singular_table_name.underscore %>.id}", { :alert => "<%= singular_table_name.humanize %> failed to update successfully." })
+      redirect_to("/<%= @plural_table_name.underscore %>/#{@the_<%= singular_table_name.underscore %>.id}", { :alert => "<%= singular_table_name.humanize %> failed to update successfully." })
     end
 <% else -%>
     @the_<%= singular_table_name.underscore %>.save
 
 <% unless skip_redirect? -%>
-    redirect_to("/<%= @plural_table_name.underscore %>/#{@the<%= singular_table_name.underscore %>.id}")
+    redirect_to("/<%= @plural_table_name.underscore %>/#{@the_<%= singular_table_name.underscore %>.id}")
 <% else -%>
       render({ :template => "<%= plural_table_name.underscore %>/show.html.erb" })
   <% end -%>

--- a/lib/generators/draft/resource/templates/views/index.html.erb
+++ b/lib/generators/draft/resource/templates/views/index.html.erb
@@ -1,3 +1,4 @@
+<% require 'indefinite_article' %>
 <div class="row mb-3">
   <div class="col-md-12">
     <h1>

--- a/lib/generators/draft/resource/templates/views/index.html.erb
+++ b/lib/generators/draft/resource/templates/views/index.html.erb
@@ -1,5 +1,4 @@
-<% $LOAD_PATH.unshift '/Gemfile' %>
-<% require 'indefinite_article' %>
+
 <div class="row mb-3">
   <div class="col-md-12">
     <h1>

--- a/lib/generators/draft/resource/templates/views/index.html.erb
+++ b/lib/generators/draft/resource/templates/views/index.html.erb
@@ -92,7 +92,7 @@
         <th>
         </th>
       </tr>
-
+<% require 'indefinite_article' %>
       <%% @list_of_<%= plural_table_name %>.each do |<%= singular_table_name.indefinitize.gsub(" ", "_") %>| %>
       <tr>
 <% if with_sentinels? -%>

--- a/lib/generators/draft/resource/templates/views/index.html.erb
+++ b/lib/generators/draft/resource/templates/views/index.html.erb
@@ -92,51 +92,51 @@
         <th>
         </th>
       </tr>
-<% require 'indefinite_article' %>
+
       <%% @list_of_<%= plural_table_name %>.each do |<%= singular_table_name.indefinitize.gsub(" ", "_") %>| %>
       <tr>
 <% if with_sentinels? -%>
-        <!-- Display <%= singular_table_name %>.id start -->
+        <!-- Display <%= singular_table_name.indefinitize.gsub(" ", "_") %>.id start -->
 <% end -%>
         <td>
-          <%%= <%= singular_table_name %>.id %>
+          <%%= <%= singular_table_name.indefinitize.gsub(" ", "_") %>.id %>
         </td>
 <% if with_sentinels? -%>
-        <!-- Display <%= singular_table_name %>.id end -->
+        <!-- Display <%= singular_table_name.indefinitize.gsub(" ", "_") %>.id end -->
 <% end -%>
 
 <% attributes.each do |attribute| -%>
 <% if with_sentinels? -%>
-        <!-- Display <%= singular_table_name %>.<%= attribute.column_name %> start -->
+        <!-- Display <%= singular_table_name.indefinitize.gsub(" ", "_") %>.<%= attribute.column_name %> start -->
 <% end -%>
         <td>
-          <%%= <%= singular_table_name %>.<%= attribute.column_name %> %>
+          <%%= <%= singular_table_name.indefinitize.gsub(" ", "_") %>.<%= attribute.column_name %> %>
         </td>
 <% if with_sentinels? -%>
-        <!-- Display <%= singular_table_name %>.<%= attribute.column_name %> end -->
+        <!-- Display <%= singular_table_name.indefinitize.gsub(" ", "_") %>.<%= attribute.column_name %> end -->
 <% end -%>
 
 <% end -%>
 <% if with_sentinels? -%>
-        <!-- Display <%= singular_table_name %>.created_at start -->
+        <!-- Display <%= singular_table_name.indefinitize.gsub(" ", "_") %>.created_at start -->
 <% end -%>
         <td>
-          <%%= time_ago_in_words(<%= singular_table_name %>.created_at) %> ago
+          <%%= time_ago_in_words(<%= singular_table_name.indefinitize.gsub(" ", "_") %>.created_at) %> ago
         </td>
 <% if with_sentinels? -%>
-        <!-- Display <%= singular_table_name %>.created_at end -->
+        <!-- Display <%= singular_table_name.indefinitize.gsub(" ", "_") %>.created_at end -->
 
-        <!-- Display <%= singular_table_name %>.updated_at start -->
+        <!-- Display <%= singular_table_name.indefinitize.gsub(" ", "_") %>.updated_at start -->
 <% end -%>
         <td>
-          <%%= time_ago_in_words(<%= singular_table_name %>.updated_at) %> ago
+          <%%= time_ago_in_words(<%= singular_table_name.indefinitize.gsub(" ", "_") %>.updated_at) %> ago
         </td>
 <% if with_sentinels? -%>
-        <!-- Display <%= singular_table_name %>.updated_at end -->
+        <!-- Display <%= singular_table_name.indefinitize.gsub(" ", "_") %>.updated_at end -->
 <% end -%>
 
         <td>
-          <a href="/<%= plural_table_name %>/<%%= <%= singular_table_name %>.id %>">
+          <a href="/<%= plural_table_name %>/<%%= <%= singular_table_name.indefinitize.gsub(" ", "_") %>.id %>">
             Show details
           </a>
         </td>

--- a/lib/generators/draft/resource/templates/views/index.html.erb
+++ b/lib/generators/draft/resource/templates/views/index.html.erb
@@ -1,3 +1,4 @@
+<% $LOAD_PATH.unshift '/Gemfile' %>
 <% require 'indefinite_article' %>
 <div class="row mb-3">
   <div class="col-md-12">

--- a/lib/generators/draft/resource/templates/views/index.html.erb
+++ b/lib/generators/draft/resource/templates/views/index.html.erb
@@ -92,7 +92,7 @@
         </th>
       </tr>
 
-      <%% @<%= plural_table_name %>.each do |<%= singular_table_name %>| %>
+      <%% @list_of_<%= plural_table_name %>.each do |<%= singular_table_name.indefinitize.gsub(" ", "_") %>| %>
       <tr>
 <% if with_sentinels? -%>
         <!-- Display <%= singular_table_name %>.id start -->

--- a/lib/generators/draft/resource/templates/views/index.html.erb
+++ b/lib/generators/draft/resource/templates/views/index.html.erb
@@ -1,4 +1,3 @@
-
 <div class="row mb-3">
   <div class="col-md-12">
     <h1>

--- a/lib/generators/draft/resource/templates/views/show.html.erb
+++ b/lib/generators/draft/resource/templates/views/show.html.erb
@@ -1,7 +1,7 @@
 <div class="row mb-3">
   <div class="col-md-8 offset-md-2">
     <h1>
-      <%= singular_table_name.humanize %> #<%%= @<%= singular_table_name %>.id %> details
+      <%= singular_table_name.humanize %> #<%%= @the_<%= singular_table_name %>.id %> details
     </h1>
 
     <div class="row mb-3">
@@ -16,7 +16,7 @@
       <!-- Delete link <%= singular_table_name %> start -->
 <% end -%>
       <div class="col">
-        <a href="/delete_<%= singular_table_name %>/<%%= @<%= singular_table_name %>.id %>" class="btn btn-block btn-outline-secondary">
+        <a href="/delete_<%= singular_table_name %>/<%%= @the_<%= singular_table_name %>.id %>" class="btn btn-block btn-outline-secondary">
           Delete <%= singular_table_name.humanize.downcase %>
         </a>
       </div>
@@ -32,13 +32,13 @@
         <%= attribute.human_name %>
       </dt>
 <% if with_sentinels? -%>
-      <!-- Display <%= attribute.column_name %> start -->
+      <!-- Display the_<%= attribute.column_name %> start -->
 <% end -%>
       <dd>
-        <%%= @<%= singular_table_name %>.<%= attribute.column_name %> %>
+        <%%= @the_<%= singular_table_name %>.<%= attribute.column_name %> %>
       </dd>
 <% if with_sentinels? -%>
-      <!-- Display <%= attribute.column_name %> end -->
+      <!-- Display the_<%= attribute.column_name %> end -->
 <% end -%>
 
 <% end -%>
@@ -49,7 +49,7 @@
       <!-- Display created_at start -->
 <% end -%>
       <dd>
-        <%%= time_ago_in_words(@<%= singular_table_name %>.created_at) %> ago
+        <%%= time_ago_in_words(@the_<%= singular_table_name %>.created_at) %> ago
       </dd>
 <% if with_sentinels? -%>
       <!-- Display created_at end -->
@@ -62,7 +62,7 @@
       <!-- Display updated_at start -->
 <% end -%>
       <dd>
-        <%%= time_ago_in_words(@<%= singular_table_name %>.updated_at) %> ago
+        <%%= time_ago_in_words(@the_<%= singular_table_name %>.updated_at) %> ago
       </dd>
 <% if with_sentinels? -%>
       <!-- Display updated_at end -->
@@ -85,11 +85,11 @@
       Edit <%= singular_table_name.humanize.downcase %>
     </h2>
 
-    <form action="/modify_<%= singular_table_name %>/<%%= @<%= singular_table_name %>.id %>" <% unless skip_post? -%> method="post" <% end -%>>
+    <form action="/modify_<%= singular_table_name %>/<%%= @the_<%= singular_table_name %>.id %>" <% unless skip_post? -%> method="post" <% end -%>>
 <% attributes.each do |attribute| -%>
 <% if attribute.field_type == :check_box -%>
       <div class="custom-control custom-checkbox mb-3">
-        <input type="checkbox" class="custom-control-input" id="<%= attribute.column_name %>_box" name="query_<%= attribute.column_name %>" value="1" <%%= "checked" if @<%= singular_table_name %>.<%= attribute.column_name %> %>>
+        <input type="checkbox" class="custom-control-input" id="<%= attribute.column_name %>_box" name="query_<%= attribute.column_name %>" value="1" <%%= "checked" if @the_<%= singular_table_name %>.<%= attribute.column_name %> %>>
 
         <label class="custom-control-label"
           for="<%= attribute.column_name %>_box"><%= attribute.column_name.humanize %></label>
@@ -102,18 +102,18 @@
         </label>
 
 <% if attribute.field_type == :text_area -%>
-        <textarea id="<%= attribute.column_name %>_box" name="query_<%= attribute.column_name %>" class="form-control" rows="3"><%%= @<%= singular_table_name %>.<%= attribute.column_name %> %></textarea>
+        <textarea id="<%= attribute.column_name %>_box" name="query_<%= attribute.column_name %>" class="form-control" rows="3"><%%= @the_<%= singular_table_name %>.<%= attribute.column_name %> %></textarea>
 <% elsif attribute.field_type.to_s.gsub(/_.*/, "").to_sym == :datetime -%>
         <input type="datetime-local" id="<%= attribute.column_name %>_box" name="query_<%= attribute.column_name %>"
-          class="form-control" value="<%%= @<%= singular_table_name %>.<%= attribute.column_name %> %>">
+          class="form-control" value="<%%= @the_<%= singular_table_name %>.<%= attribute.column_name %> %>">
 <% elsif attribute.field_type.to_s.gsub(/_.*/, "").to_sym == :date -%>
-        <input type="date" id="<%= attribute.column_name %>_box" name="query_<%= attribute.column_name %>" class="form-control" value="<%%= @<%= singular_table_name %>.<%= attribute.column_name %> %>">
+        <input type="date" id="<%= attribute.column_name %>_box" name="query_<%= attribute.column_name %>" class="form-control" value="<%%= @the_<%= singular_table_name %>.<%= attribute.column_name %> %>">
 <% elsif attribute.field_type.to_s.gsub(/_.*/, "").to_sym == :time -%>
-        <input type="time" id="<%= attribute.column_name %>_box" name="query_<%= attribute.column_name %>" class="form-control" value="<%%= @<%= singular_table_name %>.<%= attribute.column_name %> %>">
+        <input type="time" id="<%= attribute.column_name %>_box" name="query_<%= attribute.column_name %>" class="form-control" value="<%%= @the_<%= singular_table_name %>.<%= attribute.column_name %> %>">
 <% elsif attribute.field_type.to_s.gsub(/_.*/, "").to_sym == :integer -%>
-        <input type="number" id="<%= attribute.column_name %>_box" name="query_<%= attribute.column_name %>" class="form-control" value="<%%= @<%= singular_table_name %>.<%= attribute.column_name %> %>">
+        <input type="number" id="<%= attribute.column_name %>_box" name="query_<%= attribute.column_name %>" class="form-control" value="<%%= @the_<%= singular_table_name %>.<%= attribute.column_name %> %>">
 <% else -%>
-        <input type="text" id="<%= attribute.column_name %>_box" name="query_<%= attribute.column_name %>" class="form-control" value="<%%= @<%= singular_table_name %>.<%= attribute.column_name %> %>">
+        <input type="text" id="<%= attribute.column_name %>_box" name="query_<%= attribute.column_name %>" class="form-control" value="<%%= @the_<%= singular_table_name %>.<%= attribute.column_name %> %>">
 <% end -%>
       </div>
 


### PR DESCRIPTION
Starting off with the winter-2020 branch, I worked on issue #86 to address the resource variable naming.  The singular variable names now start with `the_` and the plural names start with `list_of_`. The block variable names were fixed using the gem indefinite_article.  They now start with a or an.  I ended up needing to leave the `require 'indefinite_article'` within the resource generator.rb file.  