### PR TITLE
Fix missing 'the' in generated delete link

### DIFF
--- a/lib/generators/draft/resource/templates/views/show.html.erb
+++ b/lib/generators/draft/resource/templates/views/show.html.erb
@@ -16,7 +16,7 @@
       <!-- Delete link <%= singular_table_name %> start -->
 <% end -%>
       <div>
-        <a href="/delete_<%= singular_table_name %>/<%%= @<%= singular_table_name %>.id %>">
+        <a href="/delete_<%= singular_table_name %>/<%%= @the_<%= singular_table_name %>.id %>">
           Delete <%= singular_table_name.humanize.downcase %>
         </a>
       </div>
@@ -89,7 +89,7 @@
 <% attributes.each do |attribute| -%>
 <% if attribute.field_type == :check_box -%>
       <div>
-        <input type="checkbox" id="<%= attribute.column_name %>_box" name="query_<%= attribute.column_name %>" value="1" <%%= "checked" if @<%= singular_table_name %>.<%= attribute.column_name %> %>>
+        <input type="checkbox" id="<%= attribute.column_name %>_box" name="query_<%= attribute.column_name %>" value="1" <%%= "checked" if @the_<%= singular_table_name %>.<%= attribute.column_name %> %>>
 
         <label for="<%= attribute.column_name %>_box">
             <%= attribute.column_name.humanize %>
@@ -103,18 +103,18 @@
         </label>
 
 <% if attribute.field_type == :text_area -%>
-        <textarea id="<%= attribute.column_name %>_box" name="query_<%= attribute.column_name %>"><%%= @<%= singular_table_name %>.<%= attribute.column_name %> %></textarea>
+        <textarea id="<%= attribute.column_name %>_box" name="query_<%= attribute.column_name %>"><%%= @the_<%= singular_table_name %>.<%= attribute.column_name %> %></textarea>
 <% elsif attribute.field_type.to_s.gsub(/_.*/, "").to_sym == :datetime -%>
         <input type="datetime-local" id="<%= attribute.column_name %>_box" name="query_<%= attribute.column_name %>"
-         value="<%%= @<%= singular_table_name %>.<%= attribute.column_name %> %>">
+         value="<%%= @the_<%= singular_table_name %>.<%= attribute.column_name %> %>">
 <% elsif attribute.field_type.to_s.gsub(/_.*/, "").to_sym == :date -%>
-        <input type="date" id="<%= attribute.column_name %>_box" name="query_<%= attribute.column_name %>" value="<%%= @<%= singular_table_name %>.<%= attribute.column_name %> %>">
+        <input type="date" id="<%= attribute.column_name %>_box" name="query_<%= attribute.column_name %>" value="<%%= @the_<%= singular_table_name %>.<%= attribute.column_name %> %>">
 <% elsif attribute.field_type.to_s.gsub(/_.*/, "").to_sym == :time -%>
-        <input type="time" id="<%= attribute.column_name %>_box" name="query_<%= attribute.column_name %>" value="<%%= @<%= singular_table_name %>.<%= attribute.column_name %> %>">
+        <input type="time" id="<%= attribute.column_name %>_box" name="query_<%= attribute.column_name %>" value="<%%= @the_<%= singular_table_name %>.<%= attribute.column_name %> %>">
 <% elsif attribute.field_type.to_s.gsub(/_.*/, "").to_sym == :integer -%>
-        <input type="number" id="<%= attribute.column_name %>_box" name="query_<%= attribute.column_name %>" value="<%%= @<%= singular_table_name %>.<%= attribute.column_name %> %>">
+        <input type="number" id="<%= attribute.column_name %>_box" name="query_<%= attribute.column_name %>" value="<%%= @the_<%= singular_table_name %>.<%= attribute.column_name %> %>">
 <% else -%>
-        <input type="text" id="<%= attribute.column_name %>_box" name="query_<%= attribute.column_name %>" value="<%%= @<%= singular_table_name %>.<%= attribute.column_name %> %>">
+        <input type="text" id="<%= attribute.column_name %>_box" name="query_<%= attribute.column_name %>" value="<%%= @the_<%= singular_table_name %>.<%= attribute.column_name %> %>">
 <% end -%>
       </div>
 


### PR DESCRIPTION
Somehow the update from https://github.com/firstdraft/draft_generators/blob/1b26414951e51b4e1d45307eea5bc2745b4fb594/lib/generators/draft/resource/templates/views/show.html.erb#L31 didn't make it in to this branch, which causes errors on the generated show page.

Also the changes from https://github.com/firstdraft/draft_generators/blob/pm-summer-2020-query-style/lib/generators/draft/resource/templates/views/show.html.erb don't seem to be included somehow?

This change fixes it.

Add to `Gemfile`
```
gem 'draft_generators', github: 'firstdraft/draft_generators', branch: 'jw-fix-missing-the'
```

then `bundle install`

```
rails g draft:resource photo image:string caption:text && rails db:migrate
```

Then `rails s` and visit `/photos` to create a photo and finally visit `/photos/1` and try editing and deleting without errors.

My test snapshot [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#snapshot/b2d10bc3-b8d3-4415-a1bf-b735347be009)
