### PR TITLE
Pm validation messages

### DIFF
--- a/lib/generators/draft/account/templates/controllers/authentication_controller.rb
+++ b/lib/generators/draft/account/templates/controllers/authentication_controller.rb
@@ -56,7 +56,7 @@ class <%= class_name.singularize %>AuthenticationController < ApplicationControl
    
       redirect_to("/", { :notice => "<%= singular_table_name.humanize %> account created successfully."})
     else
-      redirect_to("/<%= singular_table_name.underscore %>_sign_up", { :alert => "<%= singular_table_name.humanize %> account failed to create successfully."})
+      redirect_to("/<%= singular_table_name.underscore %>_sign_up", { :alert => @<%= singular_table_name%>.errors.full_messages.to_sentence })
     end
   end
     
@@ -82,7 +82,7 @@ class <%= class_name.singularize %>AuthenticationController < ApplicationControl
 
       redirect_to("/", { :notice => "<%= singular_table_name.humanize %> account updated successfully."})
     else
-      render({ :template => "<%= singular_table_name.underscore %>_authentication/edit_profile_with_errors.html.erb" })
+      render({ :template => "<%= singular_table_name.underscore %>_authentication/edit_profile_with_errors.html.erb" , :alert => @<%= singular_table_name%>.errors.full_messages.to_sentence })
     end
   end
 


### PR DESCRIPTION
I added the code of `.errors.full_messages.to_sentence` to the create and update actions in the draft:account authentication_controller. 

To test, go to the snapshot below.  I have already run the `draft:account` command.  If you go to `/user_sign_up` and add the same user twice it will show a message, then if you go to `sign_in` and try to sign in with a bad password you should get a different message.  To be clear, I have have already gone to the application.html layout page and placed code to make the messages visible.  

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#snapshot/dc0edb26-8abf-4f8c-969f-694ed8101dea)
