### PR TITLE
added border 1 to draft resource generator

### DIFF
--- a/lib/generators/draft/resource/templates/views/index.html.erb
+++ b/lib/generators/draft/resource/templates/views/index.html.erb
@@ -68,7 +68,7 @@
 <% end -%>
 <div>
   <div>
-    <table>
+    <table border="1">
       <tr>
         <th>
           ID


### PR DESCRIPTION
This resolves #100. 

The Problem: There was no border around the table for the draft:resource generator. 

The Solution: Add `border = "1"` to the HTML table tag

What the solution looks like.

<img width="596" alt="Screen Shot 2021-06-25 at 11 49 52 AM" src="https://user-images.githubusercontent.com/11845081/123459165-8c020a80-d5ab-11eb-932a-0bcf1cea15bd.png">

How to test: In this [snapshot](https://gitpod.io/#snapshot/42bc46c3-7d98-4434-a23a-cf449f39383a
), I have changed the gem file to pull from this branch.  To test open the console, run `rails g draft:resource item item:string`. Then run `rails db:migrate`.  After this you can run `bin/server` and visit the newly created table at `/items`

