### PR TITLE
Show validation failure messages in alerts

### DIFF
--- a/lib/generators/draft/account/account_generator.rb
+++ b/lib/generators/draft/account/account_generator.rb
@@ -96,6 +96,7 @@ module Draft
         
         def load_current_#{singular_table_name.underscore}
           the_id = session[:#{singular_table_name.underscore}_id]
+          
           @current_#{singular_table_name.underscore} = #{class_name.singularize}.where({ :id => the_id }).first
         end
         

--- a/lib/generators/draft/resource/templates/controllers/controller.rb
+++ b/lib/generators/draft/resource/templates/controllers/controller.rb
@@ -32,7 +32,7 @@ class <%= plural_table_name.camelize %>Controller < ApplicationController
       the_<%= singular_table_name.underscore %>.save
       redirect_to("/<%= plural_table_name.underscore %>", { :notice => "<%= singular_table_name.humanize %> created successfully." })
     else
-      redirect_to("/<%= plural_table_name.underscore %>", { :notice => "<%= singular_table_name.humanize %> failed to create successfully." })
+      redirect_to("/<%= plural_table_name.underscore %>", { :alert => <%= singular_table_name.underscore %>.errors.full_messages.to_sentence })
     end
 <% else -%>
     the_<%= singular_table_name.underscore %>.save
@@ -64,7 +64,7 @@ class <%= plural_table_name.camelize %>Controller < ApplicationController
       the_<%= singular_table_name.underscore %>.save
       redirect_to("/<%= plural_table_name.underscore %>/#{the_<%= singular_table_name.underscore %>.id}", { :notice => "<%= singular_table_name.humanize %> updated successfully."} )
     else
-      redirect_to("/<%= plural_table_name.underscore %>/#{the_<%= singular_table_name.underscore %>.id}", { :alert => "<%= singular_table_name.humanize %> failed to update successfully." })
+      redirect_to("/<%= plural_table_name.underscore %>/#{the_<%= singular_table_name.underscore %>.id}", { :alert => <%= singular_table_name.underscore %>.errors.full_messages.to_sentence })
     end
 <% else -%>
     the_<%= singular_table_name.underscore %>.save


### PR DESCRIPTION
Currently, generated code shows only "The <record> failed to create/update successfully." in a `notice` if validations fail.

This patch displays validation failure messages in an `alert` instead.