### PR TITLE
Update parent name to support Rails 6.1+

### DIFF
--- a/lib/generators/draft/layout/templates/_navbar.html.erb
+++ b/lib/generators/draft/layout/templates/_navbar.html.erb
@@ -1,7 +1,7 @@
 <nav class="navbar navbar-expand-lg navbar-light bg-light mb-4">
   <div class="container">
     <a class="navbar-brand" href="/">
-      <%= Rails.application.class.parent_name %>
+      <%= Rails.application.class.module_parent_name.underscore %>
     </a>
 
     <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#collapsible-nav-links" aria-controls="collapsible-nav-links" aria-expanded="false" aria-label="Toggle navigation">

--- a/lib/generators/draft/layout/templates/layout.html.erb
+++ b/lib/generators/draft/layout/templates/layout.html.erb
@@ -2,7 +2,7 @@
 <html>
 <head>
   <title>
-    <%= Rails.application.class.parent_name %>
+    <%= Rails.application.class.module_parent_name.underscore %>
   </title>
 
   <!-- Expand the number of characters we can use in the document beyond basic ASCII 🎉 -->


### PR DESCRIPTION
Resolves #115 

In Rails 6, this warning appears:

> DEPRECATION WARNING: `Module#parent_name` has been renamed to `module_parent_name`.
`parent_name` is deprecated and will be removed in Rails 6.1.

Now that AD2 (and soon AD1) projects are Rails 6.1+, we need to use `module_parent_name` instead. This PR updates the use of `parent_name` to `module_parent_name`.

I don't think backwards compatibility needs to be supported— since there are other branches/commits that past students have checked out. Perhaps this should be merged into `master` instead?

